### PR TITLE
Support default subnet configuration

### DIFF
--- a/tunelo/api/schema.py
+++ b/tunelo/api/schema.py
@@ -35,8 +35,8 @@ UUID = {
     # TODO until version >= 4 of jsonschema is released, uuid format does NO validation
     "format": "uuid",
 }
-# Presently, JSON-Schema does not validate CIDR types, so this has to be validated
-# manually. A subnet should be validated as CIDR | UUID.
+# The subnet can be a name, UUID, or CIDR notation; its value should be parsed
+# accordingly when being interpreted.
 SUBNET = STRING
 
 

--- a/tunelo/conf/default.py
+++ b/tunelo/conf/default.py
@@ -7,6 +7,16 @@ from oslo_config import cfg
 
 GROUP = "DEFAULT"
 
+default_opts = [
+    cfg.StrOpt(
+        "default_subnet",
+        help=(
+            "A default subnet (name or UUID) to use in case no subnet is specified "
+            "by the end-user. Channels will be allocated on this subnet."
+        ),
+    )
+]
+
 path_opts = [
     cfg.StrOpt(
         "pybasedir",
@@ -84,4 +94,4 @@ utils_opts = [
     ),
 ]
 
-opts = chain(*[path_opts, service_opts, exc_log_opts, utils_opts])
+opts = chain(*[default_opts, path_opts, service_opts, exc_log_opts, utils_opts])


### PR DESCRIPTION
Tunelo is often configured to only give out ports on a single subnet,
it makes sense therefore to allow the operator to configure that it
use this subnet whenever there is no other more specific information as
to the target subnet provided by the request.