### PR TITLE
Invert binding profile schema

### DIFF
--- a/tunelo/api/channels.py
+++ b/tunelo/api/channels.py
@@ -225,13 +225,21 @@ def destroy_channel(uuid):
 @schema.validate(uuid=schema.uuid, patch=schema.UPDATE_CHANNEL_SCHEMA)
 def update_channel(uuid, patch=None):
     """Implements the UpdateChannel API function"""
+    existing, _ = get_channel_by_uuid(uuid)
+
+    channel_type = get_channel_type(existing)
+    if channel_type not in schema.VALID_CHANNEL_TYPES:
+        raise MalformedChannel(
+            f"Channel {uuid} has unknown channel type {channel_type}."
+        )
+
     # Because properties are nested, and we don't want to fully overwrite,
     # we update the fields manually rather than using dict.update() on the whole port
     update_dict = {}
     name = patch.get("name")
     properties = patch.get("properties")
     if properties:
-        channel_properties = get_channel_properties(spoke)
+        channel_properties = get_channel_properties(existing)
         channel_properties.update(properties)
         update_dict["binding:profile"] = channel_properties
     if name:
@@ -240,7 +248,6 @@ def update_channel(uuid, patch=None):
     get_neutron_client().update_port(uuid, body={"port": update_dict})
 
     spoke, peers = get_channel_by_uuid(uuid)
-
     return create_channel_representation(spoke, peers)
 
 

--- a/tunelo/api/channels.py
+++ b/tunelo/api/channels.py
@@ -1,4 +1,3 @@
-import itertools
 import random
 from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
 from typing import List, Tuple
@@ -14,10 +13,8 @@ from tunelo.api.hooks import get_neutron_client, route
 from tunelo.api.schema import hub_device_owner_pattern, spoke_device_owner_pattern
 from tunelo.api.utils import (
     create_channel_representation,
-    create_hub_peer_representation,
     filter_ports_by_device_owner,
     get_channel_device_owner,
-    get_channel_peers,
     get_channel_peers_spokes,
     get_channel_project_id,
     get_channel_properties,

--- a/tunelo/api/schema.py
+++ b/tunelo/api/schema.py
@@ -14,9 +14,6 @@ from tunelo.common.exception import MissingParameterValue
 spoke_device_owner_pattern = re.compile(r"channel:(?P<channel_type>.*):spoke")
 hub_device_owner_pattern = re.compile(r"channel:(?P<channel_type>.*):hub")
 device_owner_pattern = re.compile(r"channel:(?P<channel_type>.*):(spoke|hub)")
-valid_hub_peer_pattern = re.compile(
-    r"(?P<public_key>.+)\|(?P<endpoint>.*)\|(?P<allowed_ips>.+)"
-)
 
 # Some JSON schema helpers
 STRING = {"type": "string"}

--- a/tunelo/api/utils.py
+++ b/tunelo/api/utils.py
@@ -1,13 +1,9 @@
-from collections import defaultdict
-from functools import partial
-
 from flask import make_response
 from oslo_log import log
 from tunelo.api.channels import KEY_BINDING_PROFILE
 
 from tunelo.api.schema import VALID_CHANNEL_TYPES
 from tunelo.api.schema import device_owner_pattern
-from tunelo.api.schema import valid_hub_peer_pattern
 from tunelo.common.exception import MalformedChannel
 
 LOG = log.getLogger(__name__)
@@ -30,7 +26,7 @@ def create_channel_representation(port, peers=None):
     for a channel are derived manually in this function to ensure that the order
     of keys in the objects returned by the API are always the same.
 
-    Args:
+    Args
         port: A dictionary which describes metadata of the port
             for which we are deriving a channel representation.
             This should be an un-modified reference to a dictionary


### PR DESCRIPTION
Now, the spoke ports store a list of hub IDs in their binding profile,
as opposed to the hubs storing a list of all _their_ peers, encoded.