### PR TITLE
Feat/enforce policy

### DIFF
--- a/etc/tunelo/policy.yaml.sample
+++ b/etc/tunelo/policy.yaml.sample
@@ -1,0 +1,18 @@
+# Retrieve channel details
+# GET  /channels
+# GET  /channels/{channel_uuid}
+#"channel:get": "role:admin or project_id:%(project_id)s"
+
+# Create a channel
+# POST  /channels
+#"channel:create": "role:admin or project_id:%(project_id)s"
+
+# Update a channel
+# PATCH  /channels/{channel_uuid}
+# PUT  /channels/{channel_uuid}
+#"channel:update": "role:admin or project_id:%(project_id)s"
+
+# Delete a channel
+# DELETE  /channels/{channel_uuid}
+#"channel:delete": "role:admin or project_id:%(project_id)s"
+

--- a/etc/tunelo/tunelo.conf.sample
+++ b/etc/tunelo/tunelo.conf.sample
@@ -200,11 +200,11 @@
 # From tunelo
 #
 
-# The IP address or hostname on which doni-api listens. (host
-# address value)
+# The IP address or hostname on which tunelo-api listens.
+# (host address value)
 #host_ip = 0.0.0.0
 
-# The TCP port on which doni-api listens. (port value)
+# The TCP port on which tunelo-api listens. (port value)
 # Minimum value: 0
 # Maximum value: 65535
 #port = 8001
@@ -215,17 +215,17 @@
 #max_limit = 1000
 
 # Public URL to use when building the links to the API
-# resources (for example, "https://doni.rocks:8001"). If None
-# the links will be built using the request's host URL. If the
-# API is operating behind a proxy, you will want to change
-# this to represent the proxy's URL. Defaults to None. Ignored
-# when proxy headers parsing is enabled via
+# resources (for example, "https://tunelo.example.com:8001").
+# If None the links will be built using the request's host
+# URL. If the API is operating behind a proxy, you will want
+# to change this to represent the proxy's URL. Defaults to
+# None. Ignored when proxy headers parsing is enabled via
 # [oslo_middleware]enable_proxy_headers_parsing option.
 # (string value)
 # Note: This option can be changed without restarting.
 #public_endpoint = <None>
 
-# Number of workers for OpenStack doni API service. The
+# Number of workers for OpenStack tunelo API service. The
 # default is equal to the number of CPUs available, but not
 # more than 4. One worker is used if the CPU number cannot be
 # detected. (integer value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ tunelo = "tunelo.conf.opts:list_opts"
 [project.entry-points."oslo.config.opts.defaults"]
 tunelo = "tunelo.conf.opts:update_opt_defaults"
 
+[project.entry-points."oslo.policy.enforcer"]
+tunelo = "tunelo.common.policy:get_oslo_policy_enforcer"
+
+[project.entry-points."oslo.policy.policies"]
+"tunelo.api" = "tunelo.common.policy:list_policies"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/tunelo/api/channels.py
+++ b/tunelo/api/channels.py
@@ -202,12 +202,18 @@ def destroy_channel(uuid):
     """Destroys a channel by UUID
 
     Deletes a spoke port.
-    Deletes the hub if this action would cause the hub to have zero peers
+    TODO: Delete the hub if this action would cause the hub to have zero
+    peers (not implemented).
 
     Args:
         uuid: the UUID of the channel must be equivalent to the ``id`` field
         of a spoke port.
     """
+    # Resolve the channel first: this raises NotFound for ports that do not
+    # exist or are not spoke ports. Otherwise, would permit arbitrary neutron
+    # ports to be deleted.
+    get_channel_by_uuid(uuid)
+
     neutron = get_neutron_client()
 
     try:

--- a/tunelo/api/channels.py
+++ b/tunelo/api/channels.py
@@ -2,12 +2,12 @@ import random
 from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
 from typing import List, Tuple
 
-from flask import Blueprint
+from flask import Blueprint, request
 from neutronclient.common.exceptions import IpAddressAlreadyAllocatedClient
 from neutronclient.common.exceptions import NotFound as NeutronNotFound
 from neutronclient.common.exceptions import PortNotFoundClient
 from oslo_log import log
-from oslo_utils import netutils, uuidutils
+from oslo_utils import netutils, strutils, uuidutils
 
 from tunelo.api import schema
 from tunelo.api.hooks import get_neutron_client, get_neutron_session, route
@@ -31,6 +31,7 @@ from tunelo.common.exception import (
     MalformedChannel,
     NotFound,
 )
+from tunelo.common.policy import authorize
 from tunelo.conf import CONF
 
 LOG = log.getLogger(__name__)
@@ -42,13 +43,30 @@ def _is_cidr(val):
     return netutils.is_valid_cidr(val) or netutils.is_valid_ipv6_cidr(val)
 
 
+def _is_all_projects(args):
+    """Whether the request opted into listing across all projects.
+
+    The bare flag (`?all_projects`) and truthy values (`=1`/`=true`) enable it,
+    while explicit falsy values (`=0`/`=false`) disable it.
+    """
+    all_projects = args.get("all_projects")
+    if all_projects:
+        try:
+            return strutils.bool_from_string(all_projects, strict=True)
+        except ValueError as exc:
+            raise InvalidParameterValue(str(exc))
+    return "all_projects" in args
+
+
 @route("/channels", blueprint=bp, methods=["GET"])
 def list_channels():
     """Implements API function ListChannels
 
-    All Neutron ports are pulled down and then channel spokes and hubs are derived
-    locally. Peer hubs for each spoke are mapped, and then a list of
-    channel representations is returned for all of the spokes
+    Neutron ports for the caller's project are pulled down and then channel
+    spokes and hubs are derived locally. Peer hubs for each spoke are mapped,
+    and then a list of channel representations is returned for all of the
+    spokes. Admins may pass ``?all_projects`` to list channels across all
+    projects.
     """
 
     def _filter_by_device_owner(filter_regex, port_list):
@@ -58,7 +76,12 @@ def list_channels():
             if filter_regex.match(get_channel_device_owner(p))
         ]
 
-    ports = get_neutron_client().list_ports()["ports"]
+    ctx = request.context
+    project_id = None if _is_all_projects(request.args) else ctx.project_id
+    authorize("channel:get", ctx, {"project_id": project_id})
+
+    port_filters = {} if project_id is None else {"project_id": project_id}
+    ports = get_neutron_client().list_ports(**port_filters)["ports"]
     spokes = _filter_by_device_owner(spoke_device_owner_pattern, ports)
     hubs = _filter_by_device_owner(hub_device_owner_pattern, ports)
 
@@ -87,6 +110,12 @@ def get_channel(uuid):
             a spoke port.
     """
     spoke, peers = get_channel_by_uuid(uuid)
+
+    authorize(
+        "channel:get",
+        request.context,
+        {"project_id": get_channel_project_id(spoke)},
+    )
 
     return create_channel_representation(spoke, peers)
 
@@ -166,7 +195,15 @@ def create_channel(channel_definition=None):
     properties = channel_definition[schema.KEY_PROPERTIES]
 
     name = channel_definition.get(schema.KEY_NAME)
-    project_id = channel_definition[schema.KEY_PROJECT_ID]
+    ctx = request.context
+    project_id = (
+        channel_definition.get(schema.KEY_PROJECT_ID) or ctx.project_id
+    )
+    if not project_id:
+        raise InvalidParameterValue(
+            "project_id is required when the request is not project-scoped."
+        )
+    authorize("channel:create", ctx, {"project_id": project_id})
     subnet = channel_definition.get(schema.KEY_SUBNET)
     channel_address = channel_definition.get(schema.KEY_CHANNEL_ADDRESS)
 
@@ -212,7 +249,13 @@ def destroy_channel(uuid):
     # Resolve the channel first: this raises NotFound for ports that do not
     # exist or are not spoke ports. Otherwise, would permit arbitrary neutron
     # ports to be deleted.
-    get_channel_by_uuid(uuid)
+    spoke, _ = get_channel_by_uuid(uuid)
+
+    authorize(
+        "channel:delete",
+        request.context,
+        {"project_id": get_channel_project_id(spoke)},
+    )
 
     neutron = get_neutron_client()
 
@@ -232,6 +275,12 @@ def destroy_channel(uuid):
 def update_channel(uuid, patch=None):
     """Implements the UpdateChannel API function"""
     existing, _ = get_channel_by_uuid(uuid)
+
+    authorize(
+        "channel:update",
+        request.context,
+        {"project_id": get_channel_project_id(existing)},
+    )
 
     channel_type = get_channel_type(existing)
     if channel_type not in schema.VALID_CHANNEL_TYPES:

--- a/tunelo/api/schema.py
+++ b/tunelo/api/schema.py
@@ -201,7 +201,8 @@ CREATE_CHANNEL_SCHEMA = schema(
         "properties": {
             # The name of the channel (optional)
             "name": STRING,
-            # The project ID for the channel
+            # The project ID for the channel (optional; defaults to the
+            # caller's project. Setting another project requires admin.)
             "project_id": UUID,
             # The subnet on which the channel will operate (UUID or CIDR) (optional)
             "subnet": SUBNET,
@@ -221,7 +222,7 @@ CREATE_CHANNEL_SCHEMA = schema(
                 "required": ["public_key"],
             },
         },
-        "required": ["project_id", "channel_type", "properties"],
+        "required": ["channel_type", "properties"],
         "additionalProperties": False,
     }
 )

--- a/tunelo/common/policy.py
+++ b/tunelo/common/policy.py
@@ -1,0 +1,102 @@
+import itertools
+import sys
+
+from oslo_config import cfg
+from oslo_policy import policy
+
+from tunelo import PROJECT_NAME
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tunelo.common.context import RequestContext
+
+CONF = cfg.CONF
+_ENFORCER = None
+
+SYSTEM_ADMIN = "role:admin"
+SYSTEM_ADMIN_OR_PROJECT_MEMBER = "role:admin or project_id:%(project_id)s"
+
+channel_rules = [
+    policy.DocumentedRuleDefault(
+        name="channel:get",
+        check_str=SYSTEM_ADMIN_OR_PROJECT_MEMBER,
+        description="Retrieve channel details",
+        operations=[
+            {"path": "/channels", "method": "GET"},
+            {"path": "/channels/{channel_uuid}", "method": "GET"},
+        ],
+    ),
+    policy.DocumentedRuleDefault(
+        name="channel:create",
+        check_str=SYSTEM_ADMIN_OR_PROJECT_MEMBER,
+        description="Create a channel",
+        operations=[{"path": "/channels", "method": "POST"}],
+    ),
+    policy.DocumentedRuleDefault(
+        name="channel:update",
+        check_str=SYSTEM_ADMIN_OR_PROJECT_MEMBER,
+        description="Update a channel",
+        operations=[
+            {"path": "/channels/{channel_uuid}", "method": "PATCH"},
+            {"path": "/channels/{channel_uuid}", "method": "PUT"},
+        ],
+    ),
+    policy.DocumentedRuleDefault(
+        name="channel:delete",
+        check_str=SYSTEM_ADMIN_OR_PROJECT_MEMBER,
+        description="Delete a channel",
+        operations=[{"path": "/channels/{channel_uuid}", "method": "DELETE"}],
+    ),
+]
+
+
+def list_policies():
+    return itertools.chain(
+        channel_rules,
+    )
+
+
+def get_enforcer():
+    global _ENFORCER
+    if not _ENFORCER:
+        _ENFORCER = policy.Enforcer(CONF)
+        _ENFORCER.register_defaults(list_policies())
+    return _ENFORCER
+
+
+def get_oslo_policy_enforcer():
+    # This method is for use by oslopolicy CLI scripts. Those scripts need the
+    # 'output-file' and 'namespace' options, but having those in sys.argv means
+    # loading the tunelo config options will fail as those are not expected to
+    # be present. So we pass in an arg list with those stripped out.
+
+    conf_args = []
+    # Start at 1 because cfg.CONF expects the equivalent of sys.argv[1:]
+    i = 1
+    while i < len(sys.argv):
+        if sys.argv[i].strip("-") in ["namespace", "output-file"]:
+            i += 2
+            continue
+        conf_args.append(sys.argv[i])
+        i += 1
+
+    cfg.CONF(conf_args, project=PROJECT_NAME)
+
+    return get_enforcer()
+
+
+def authorize(rule, context: "RequestContext", target: "dict" = None):
+    """Check if the request is authorized according to a given rule.
+
+    Args:
+        rule (str): The policy rule.
+        context (RequestContext): The request context.
+        target (dict): The target domain object, if any.
+
+    Raises:
+        PolicyNotAuthorized: If the rule is not satisfied.
+    """
+    return get_enforcer().authorize(
+        rule, target or {}, context.to_policy_values(), do_raise=True
+    )

--- a/tunelo/tests/test_channels_authz.py
+++ b/tunelo/tests/test_channels_authz.py
@@ -1,12 +1,18 @@
 from unittest import mock
 
-from flask import Flask
+from flask import Flask, request
+from oslo_config import fixture as cfg_fixture
 from oslotest import base
 
+from tunelo import PROJECT_NAME
 from tunelo.api import channels
+from tunelo.common import context as tunelo_context
+from tunelo.common import policy
 
 SPOKE_UUID = "11111111-1111-4111-8111-111111111111"
+HUB_UUID = "22222222-2222-4222-8222-222222222222"
 PROJECT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+PROJECT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 
 
 def fake_port(
@@ -28,16 +34,154 @@ def fake_port(
     }
 
 
-class TestDestroyChannel(base.BaseTestCase):
+class ChannelsAuthzTestBase(base.BaseTestCase):
     def setUp(self):
         super().setUp()
+
+        self.cfg = self.useFixture(cfg_fixture.Config(channels.CONF))
+        # The enforcer requires a parsed CONF to locate the policy file.
+        # The API service parses CONF at startup; tests must do it here.
+        policy.CONF([], project=PROJECT_NAME, default_config_files=[])
+
+        enforcer_patch = mock.patch.object(policy, "_ENFORCER", None)
+        self.addCleanup(enforcer_patch.stop)
+        enforcer_patch.start()
 
         client_patch = mock.patch.object(channels, "get_neutron_client")
         self.addCleanup(client_patch.stop)
         self.neutron = client_patch.start().return_value
-        self.neutron.list_ports.return_value = {"ports": []}
 
         self.app = Flask(__name__)
+
+    def _request_context(self, path="/channels", roles=None, **kwargs):
+        ctx = self.app.test_request_context(path, **kwargs)
+
+        class _ContextInjector:
+            def __init__(self, inner):
+                self.inner = inner
+
+            def __enter__(self):
+                rv = self.inner.__enter__()
+                request.context = tunelo_context.RequestContext(
+                    project_id=PROJECT_A,
+                    roles=roles or ["member"],
+                    overwrite=False,
+                )
+                return rv
+
+            def __exit__(self, *exc):
+                return self.inner.__exit__(*exc)
+
+        return _ContextInjector(ctx)
+
+    @staticmethod
+    def _status_code(res):
+        # Handlers return ("", 200) tuples on empty success, dicts on JSON
+        # success, and flask Response objects (via make_error_response) on
+        # error.
+        if isinstance(res, tuple):
+            return res[1]
+        if isinstance(res, dict):
+            return 200
+        return res.status_code
+
+
+class TestListChannels(ChannelsAuthzTestBase):
+    def test_member_list_is_scoped_to_own_project(self):
+        self.neutron.list_ports.return_value = {
+            "ports": [fake_port(peers=[HUB_UUID])]
+        }
+
+        with self._request_context():
+            res = channels.list_channels()
+
+        self.neutron.list_ports.assert_called_once_with(project_id=PROJECT_A)
+        self.assertEqual(1, len(res["channels"]))
+
+    def test_member_all_projects_rejected(self):
+        with self._request_context("/channels?all_projects=1"):
+            res = channels.list_channels()
+
+        self.assertEqual(403, self._status_code(res))
+        self.neutron.list_ports.assert_not_called()
+
+    def test_admin_all_projects_unscoped(self):
+        self.neutron.list_ports.return_value = {"ports": []}
+
+        with self._request_context(
+            "/channels?all_projects=1", roles=["admin"]
+        ):
+            res = channels.list_channels()
+
+        self.neutron.list_ports.assert_called_once_with()
+        self.assertEqual({"channels": []}, res)
+
+    def test_admin_bare_all_projects_flag_unscoped(self):
+        self.neutron.list_ports.return_value = {"ports": []}
+
+        with self._request_context("/channels?all_projects", roles=["admin"]):
+            res = channels.list_channels()
+
+        self.neutron.list_ports.assert_called_once_with()
+        self.assertEqual({"channels": []}, res)
+
+    def test_all_projects_explicit_false_is_scoped(self):
+        # An explicit falsy value disables all-projects mode.
+        self.neutron.list_ports.return_value = {"ports": []}
+
+        with self._request_context("/channels?all_projects=0"):
+            res = channels.list_channels()
+
+        self.neutron.list_ports.assert_called_once_with(project_id=PROJECT_A)
+        self.assertEqual({"channels": []}, res)
+
+    def test_all_projects_invalid_value_rejected(self):
+        with self._request_context("/channels?all_projects=notabool"):
+            res = channels.list_channels()
+
+        self.assertEqual(400, self._status_code(res))
+        self.neutron.list_ports.assert_not_called()
+
+
+class TestGetChannel(ChannelsAuthzTestBase):
+    def setUp(self):
+        super().setUp()
+        self.neutron.list_ports.return_value = {"ports": []}
+
+    def test_owner_allowed(self):
+        self.neutron.show_port.return_value = {"port": fake_port()}
+
+        with self._request_context(f"/channels/{SPOKE_UUID}"):
+            res = channels.get_channel(SPOKE_UUID)
+
+        self.assertEqual(200, self._status_code(res))
+        self.assertEqual(SPOKE_UUID, res["uuid"])
+
+    def test_non_owner_rejected(self):
+        self.neutron.show_port.return_value = {
+            "port": fake_port(project_id=PROJECT_B)
+        }
+
+        with self._request_context(f"/channels/{SPOKE_UUID}"):
+            res = channels.get_channel(SPOKE_UUID)
+
+        self.assertEqual(403, self._status_code(res))
+
+    def test_admin_allowed_for_other_project(self):
+        self.neutron.show_port.return_value = {
+            "port": fake_port(project_id=PROJECT_B)
+        }
+
+        with self._request_context(f"/channels/{SPOKE_UUID}", roles=["admin"]):
+            res = channels.get_channel(SPOKE_UUID)
+
+        self.assertEqual(200, self._status_code(res))
+
+
+class TestDestroyChannel(ChannelsAuthzTestBase):
+    def setUp(self):
+        super().setUp()
+        self.neutron.list_ports.return_value = {"ports": []}
 
     def test_non_spoke_port_not_deleted(self):
         # Regression test: arbitrary Neutron ports must not be deletable
@@ -46,17 +190,121 @@ class TestDestroyChannel(base.BaseTestCase):
             "port": fake_port(device_owner="compute:nova")
         }
 
-        with self.app.test_request_context(f"/channels/{SPOKE_UUID}"):
+        with self._request_context(f"/channels/{SPOKE_UUID}"):
             res = channels.destroy_channel(SPOKE_UUID)
 
-        self.assertEqual(404, res.status_code)
+        self.assertEqual(404, self._status_code(res))
         self.neutron.delete_port.assert_not_called()
 
-    def test_spoke_port_deleted(self):
-        self.neutron.show_port.return_value = {"port": fake_port()}
+    def test_non_owner_rejected(self):
+        self.neutron.show_port.return_value = {
+            "port": fake_port(project_id=PROJECT_B)
+        }
 
-        with self.app.test_request_context(f"/channels/{SPOKE_UUID}"):
+        with self._request_context(f"/channels/{SPOKE_UUID}"):
             res = channels.destroy_channel(SPOKE_UUID)
 
-        self.assertEqual(("", 200), res)
+        self.assertEqual(403, self._status_code(res))
+        self.neutron.delete_port.assert_not_called()
+
+    def test_owner_allowed(self):
+        self.neutron.show_port.return_value = {"port": fake_port()}
+
+        with self._request_context(f"/channels/{SPOKE_UUID}"):
+            res = channels.destroy_channel(SPOKE_UUID)
+
+        self.assertEqual(200, self._status_code(res))
         self.neutron.delete_port.assert_called_once_with(SPOKE_UUID)
+
+
+class TestUpdateChannel(ChannelsAuthzTestBase):
+    def setUp(self):
+        super().setUp()
+        self.neutron.list_ports.return_value = {"ports": []}
+
+    def test_non_owner_rejected(self):
+        self.neutron.show_port.return_value = {
+            "port": fake_port(project_id=PROJECT_B)
+        }
+
+        with self._request_context(
+            f"/channels/{SPOKE_UUID}",
+            method="PATCH",
+            json={"name": "new-name"},
+        ):
+            res = channels.update_channel(SPOKE_UUID)
+
+        self.assertEqual(403, self._status_code(res))
+        self.neutron.update_port.assert_not_called()
+
+    def test_owner_allowed(self):
+        self.neutron.show_port.return_value = {"port": fake_port()}
+
+        with self._request_context(
+            f"/channels/{SPOKE_UUID}",
+            method="PATCH",
+            json={"name": "new-name"},
+        ):
+            res = channels.update_channel(SPOKE_UUID)
+
+        self.assertEqual(200, self._status_code(res))
+        self.neutron.update_port.assert_called_once()
+
+
+class TestCreateChannel(ChannelsAuthzTestBase):
+    def setUp(self):
+        super().setUp()
+
+        for helper in ("get_or_create_subnet", "resolve_hub", "create_spoke"):
+            patcher = mock.patch.object(channels, helper)
+            self.addCleanup(patcher.stop)
+            setattr(self, helper, patcher.start())
+
+        self.get_or_create_subnet.return_value = {
+            "id": "subnet-1",
+            "cidr": "10.0.0.0/24",
+            "network_id": "net-1",
+        }
+        self.resolve_hub.return_value = fake_port(
+            uuid=HUB_UUID, device_owner="channel:wireguard:hub"
+        )
+        self.create_spoke.return_value = fake_port(peers=[HUB_UUID])
+
+    def _body(self, project_id=None):
+        body = {
+            "channel_type": "wireguard",
+            "properties": {"public_key": "dGVzdC1wdWJsaWMta2V5"},
+        }
+        if project_id:
+            body["project_id"] = project_id
+        return body
+
+    def test_project_id_defaults_to_caller(self):
+        with self._request_context(
+            "/channels", method="POST", json=self._body()
+        ):
+            res = channels.create_channel()
+
+        self.assertEqual(200, self._status_code(res))
+        self.assertEqual(PROJECT_A, self.create_spoke.call_args.args[0])
+
+    def test_member_mismatched_project_rejected(self):
+        with self._request_context(
+            "/channels", method="POST", json=self._body(project_id=PROJECT_B)
+        ):
+            res = channels.create_channel()
+
+        self.assertEqual(403, self._status_code(res))
+        self.create_spoke.assert_not_called()
+
+    def test_admin_may_create_in_other_project(self):
+        with self._request_context(
+            "/channels",
+            method="POST",
+            json=self._body(project_id=PROJECT_B),
+            roles=["admin"],
+        ):
+            res = channels.create_channel()
+
+        self.assertEqual(200, self._status_code(res))
+        self.assertEqual(PROJECT_B, self.create_spoke.call_args.args[0])

--- a/tunelo/tests/test_channels_authz.py
+++ b/tunelo/tests/test_channels_authz.py
@@ -1,0 +1,62 @@
+from unittest import mock
+
+from flask import Flask
+from oslotest import base
+
+from tunelo.api import channels
+
+SPOKE_UUID = "11111111-1111-4111-8111-111111111111"
+PROJECT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+def fake_port(
+    uuid=SPOKE_UUID,
+    device_owner="channel:wireguard:spoke",
+    project_id=PROJECT_A,
+    peers=None,
+):
+    return {
+        "id": uuid,
+        "device_owner": device_owner,
+        "project_id": project_id,
+        "status": "ACTIVE",
+        "fixed_ips": [{"ip_address": "10.0.0.2", "subnet_id": "subnet-1"}],
+        "binding:profile": {
+            "public_key": "dGVzdC1wdWJsaWMta2V5",
+            "peers": peers or [],
+        },
+    }
+
+
+class TestDestroyChannel(base.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        client_patch = mock.patch.object(channels, "get_neutron_client")
+        self.addCleanup(client_patch.stop)
+        self.neutron = client_patch.start().return_value
+        self.neutron.list_ports.return_value = {"ports": []}
+
+        self.app = Flask(__name__)
+
+    def test_non_spoke_port_not_deleted(self):
+        # Regression test: arbitrary Neutron ports must not be deletable
+        # through this endpoint.
+        self.neutron.show_port.return_value = {
+            "port": fake_port(device_owner="compute:nova")
+        }
+
+        with self.app.test_request_context(f"/channels/{SPOKE_UUID}"):
+            res = channels.destroy_channel(SPOKE_UUID)
+
+        self.assertEqual(404, res.status_code)
+        self.neutron.delete_port.assert_not_called()
+
+    def test_spoke_port_deleted(self):
+        self.neutron.show_port.return_value = {"port": fake_port()}
+
+        with self.app.test_request_context(f"/channels/{SPOKE_UUID}"):
+            res = channels.destroy_channel(SPOKE_UUID)
+
+        self.assertEqual(("", 200), res)
+        self.neutron.delete_port.assert_called_once_with(SPOKE_UUID)

--- a/tunelo/tests/test_policy.py
+++ b/tunelo/tests/test_policy.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+from oslo_config import fixture as cfg_fixture
+from oslo_policy.policy import PolicyNotAuthorized
+from oslotest import base
+
+from tunelo import PROJECT_NAME
+from tunelo.common import context as tunelo_context
+from tunelo.common import policy
+
+
+class PolicyTest(base.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.cfg = self.useFixture(cfg_fixture.Config(policy.CONF))
+        # The enforcer requires a parsed CONF to locate the policy file.
+        # The API service parses CONF at startup; tests must do it here.
+        policy.CONF([], project=PROJECT_NAME, default_config_files=[])
+
+        enforcer_patch = mock.patch.object(policy, "_ENFORCER", None)
+        self.addCleanup(enforcer_patch.stop)
+        enforcer_patch.start()
+
+    def _make_context(self, project_id, roles):
+        return tunelo_context.RequestContext(
+            project_id=project_id, roles=roles, overwrite=False
+        )
+
+    def test_owner_allowed(self):
+        ctx = self._make_context("proj-a", ["member"])
+        self.assertTrue(
+            policy.authorize("channel:get", ctx, {"project_id": "proj-a"})
+        )
+
+    def test_non_owner_rejected(self):
+        ctx = self._make_context("proj-a", ["member"])
+        for rule in (
+            "channel:get",
+            "channel:create",
+            "channel:update",
+            "channel:delete",
+        ):
+            self.assertRaises(
+                PolicyNotAuthorized,
+                policy.authorize,
+                rule,
+                ctx,
+                {"project_id": "proj-b"},
+            )
+
+    def test_admin_allowed_for_other_project(self):
+        ctx = self._make_context("admin-proj", ["admin"])
+        self.assertTrue(
+            policy.authorize("channel:delete", ctx, {"project_id": "proj-b"})
+        )
+
+    def test_admin_allowed_for_null_project_target(self):
+        ctx = self._make_context("admin-proj", ["admin"])
+        self.assertTrue(
+            policy.authorize("channel:get", ctx, {"project_id": None})
+        )
+
+    def test_non_admin_rejected_for_null_project_target(self):
+        ctx = self._make_context("proj-a", ["member"])
+        self.assertRaises(
+            PolicyNotAuthorized,
+            policy.authorize,
+            "channel:get",
+            ctx,
+            {"project_id": None},
+        )


### PR DESCRIPTION
Tunelo completely lacked policy enforcement. This fixes a pretty dire oversight in "delete", and applies a default "admin_or_owner" policy check to all api endpoints.

Important to note, tunelo still uses its service account for making neutron API requests! The project context from the request is *only* used for the authorization check, and doesn't change the context tunelo uses to talk to neutron.