### PR TITLE
fix evenlet shutdown behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Chameleon on-demand tunnel provisioning service"
 authors = [{ name = "Chameleon", email = "contact@chameleoncloud.org" }]
 requires-python = ">=3.9"
 dependencies = [
+    "eventlet",
     "Flask",
     "jsonschema",
     "keystonemiddleware",

--- a/tunelo/cmd/__init__.py
+++ b/tunelo/cmd/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import eventlet
+
+eventlet.monkey_patch(os=False)


### PR DESCRIPTION
we never called eventlet.monkeypatch(). This lead to a case where the tunelo service would hang on shutdown, as the threads would never exit.